### PR TITLE
prepare contextualization schema checking skeleton

### DIFF
--- a/occo/infraprocessor/node_resolution.py
+++ b/occo/infraprocessor/node_resolution.py
@@ -141,3 +141,25 @@ class IdentityResolver(Resolver):
         node_definition['node_id'] = self.node_id
         node_definition['infra_id'] = desc['infra_id']
         node_definition['user_id'] = desc['user_id']
+
+class ContextSchemaChecker(factory.MultiBackend):
+    def __init__(self):
+        return
+
+    def perform_check(self, data):
+        raise NotImplementedError()
+
+    def get_missing_keys(self, data, req_keys):
+        missing_keys = list()
+        for rkey in req_keys:
+            if rkey not in data:
+                missing_keys.append(rkey)
+        return missing_keys
+
+    def get_invalid_keys(self, data, valid_keys):
+        invalid_keys = list()
+        for key in data:
+            if key not in valid_keys:
+                invalid_keys.append(key)
+        return invalid_keys
+

--- a/occo/plugins/infraprocessor/node_resolution/cloudbroker.py
+++ b/occo/plugins/infraprocessor/node_resolution/cloudbroker.py
@@ -30,11 +30,14 @@ import sys
 import yaml
 import jinja2
 from occo.infraprocessor.node_resolution import Resolver
+from occo.exceptions import SchemaError
+
+PROTOCOL_ID = 'cloudbroker'
 
 log = logging.getLogger('occo.infraprocessor.node_resolution.cloudbroker')
 datalog = logging.getLogger('occo.data.infraprocessor.node_resolution.cloudbroker')
 
-@factory.register(Resolver, 'cloudbroker')
+@factory.register(Resolver, PROTOCOL_ID)
 class CloudBrokerResolver(Resolver):
     """
     Implementation of :class:`Resolver` for implementations for `cloudbroker`_..
@@ -206,3 +209,21 @@ class CloudBrokerResolver(Resolver):
         if 'files' in node_definition.get('contextualisation',dict()):
             data['files'] = node_definition['contextualisation']['files']
         node_definition.update(data)
+
+@factory.register(ContextSchemaChecker, PROTOCOL_ID)
+class CloudbrokerSchemaChecker(ContextSchemaChecker):
+    def __init__(self):
+#        super(__init__(), self)
+        self.req_keys = ["type"]
+        self.opt_keys = []
+    def perform_check(self, data):
+        missing_keys = ContextSchemaChecker.get_missing_keys(self, data, self.req_keys)
+        if missing_keys:
+            msg = "missing required keys: " + ', '.join(str(key) for key in missing_keys)
+            raise SchemaError(msg)
+        valid_keys = self.req_keys + self.opt_keys
+        invalid_keys = ContextSchemaChecker.get_invalid_keys(self, data, valid_keys)
+        if invalid_keys:
+            msg = "invalid keys found: " + ', '.join(str(key) for key in invalid_keys)
+            raise SchemaError(msg)
+        return True

--- a/occo/plugins/infraprocessor/node_resolution/cloudbroker.py
+++ b/occo/plugins/infraprocessor/node_resolution/cloudbroker.py
@@ -29,7 +29,7 @@ import occo.util.factory as factory
 import sys
 import yaml
 import jinja2
-from occo.infraprocessor.node_resolution import Resolver
+from occo.infraprocessor.node_resolution import Resolver, ContextSchemaChecker
 from occo.exceptions import SchemaError
 
 PROTOCOL_ID = 'cloudbroker'

--- a/occo/plugins/infraprocessor/node_resolution/cloudinit.py
+++ b/occo/plugins/infraprocessor/node_resolution/cloudinit.py
@@ -31,7 +31,7 @@ import occo.util.factory as factory
 import sys
 import yaml
 import jinja2
-from occo.infraprocessor.node_resolution import Resolver
+from occo.infraprocessor.node_resolution import Resolver, ContextSchemaChecker
 from occo.exceptions import SchemaError
 
 PROTOCOL_ID = 'cloudinit'

--- a/occo/plugins/infraprocessor/node_resolution/cloudinit.py
+++ b/occo/plugins/infraprocessor/node_resolution/cloudinit.py
@@ -32,11 +32,14 @@ import sys
 import yaml
 import jinja2
 from occo.infraprocessor.node_resolution import Resolver
+from occo.exceptions import SchemaError
+
+PROTOCOL_ID = 'cloudinit'
 
 log = logging.getLogger('occo.infraprocessor.node_resolution.cloudinit')
 datalog = logging.getLogger('occo.data.infraprocessor.node_resolution.cloudinit')
 
-@factory.register(Resolver, 'cloudinit')
+@factory.register(Resolver, PROTOCOL_ID)
 class CloudinitResolver(Resolver):
     """
     Implementation of :class:`Resolver` for implementations for `cloud-init`_ .
@@ -245,3 +248,22 @@ class CloudinitResolver(Resolver):
 
         # Check context
         self.check_template(node_definition)
+
+@factory.register(ContextSchemaChecker, PROTOCOL_ID)
+class CloudinitSchemaChecker(ContextSchemaChecker):
+    def __init__(self):
+#        super(__init__(), self)
+        self.req_keys = ["type"]
+        self.opt_keys = []
+    def perform_check(self, data):
+        missing_keys = ContextSchemaChecker.get_missing_keys(self, data, self.req_keys)
+        if missing_keys:
+            msg = "missing required keys: " + ', '.join(str(key) for key in missing_keys)
+            raise SchemaError(msg)
+        valid_keys = self.req_keys + self.opt_keys
+        invalid_keys = ContextSchemaChecker.get_invalid_keys(self, data, valid_keys)
+        if invalid_keys:
+            msg = "invalid keys found: " + ', '.join(str(key) for key in invalid_keys)
+            raise SchemaError(msg)
+        return True
+


### PR DESCRIPTION
please merge and fill cloudbroker and cloudinit with required and optional keys - also, if docker resolver is added, create the corresponding DockerSchemaChecker class in the plugin (based on BasicContextSchemaChecker in basic.py)
